### PR TITLE
Generate a ChimeraX command file to open results in ChimeraX/ISOLDE

### DIFF
--- a/servalcat/refine/refine_spa.py
+++ b/servalcat/refine/refine_spa.py
@@ -316,6 +316,9 @@ Weight used: {final_weight:.3e}
 Open refined model and {diffmap_prefix}.mtz with COOT:
 coot --script {prefix}_coot.py
 
+Open refined model, map and difference map with ChimeraX/ISOLDE:
+chimerax {prefix}_chimerax.cxc
+
 {map_peaks_msg}
 =============================================================================
 """.format(rmsbond=rmsbond,

--- a/servalcat/spa/fofc.py
+++ b/servalcat/spa/fofc.py
@@ -382,6 +382,7 @@ def write_chimerax_script(cxc_out, model_file, fo_mrc_file, fofc_mrc_file):
         ofs.write('open {}\n'.format(model_file))
         ofs.write('open {}\n'.format(fo_mrc_file))
         ofs.write('open {}\n'.format(fofc_mrc_file))
+        ofs.write('volume #3 level 4 level -4 color #00FF00 color #FF0000 squaremesh false cap false style mesh meshlighting false\n')
         ofs.write('isolde start\n')
         ofs.write('clipper associate #2 toModel #1\n')
         ofs.write('clipper associate #3 toModel #1\n')

--- a/servalcat/spa/fofc.py
+++ b/servalcat/spa/fofc.py
@@ -377,6 +377,16 @@ def write_coot_script(py_out, model_file, mtz_file, contour_fo=1.2, contour_fofc
                 ofs.write("add_molecular_symmetry(imol, {})\n".format(",".join(str(x) for x in v)))
 # write_coot_script()
 
+def write_chimerax_script(cxc_out, model_file, fo_mrc_file, fofc_mrc_file):
+    with open(cxc_out, "w") as ofs:
+        ofs.write('open {}\n'.format(model_file))
+        ofs.write('open {}\n'.format(fo_mrc_file))
+        ofs.write('open {}\n'.format(fofc_mrc_file))
+        ofs.write('isolde start\n')
+        ofs.write('clipper associate #2 toModel #1\n')
+        ofs.write('clipper associate #3 toModel #1\n')
+# write_chimerax_script()
+
 def main(args):
     if not args.halfmaps and not args.map:
         raise SystemExit("Error: give --halfmaps or --map")

--- a/servalcat/spa/run_refmac.py
+++ b/servalcat/spa/run_refmac.py
@@ -311,6 +311,12 @@ def calc_fofc(st, st_expanded, maps, monlib, model_format, args, diffmap_prefix=
                                contour_fo=None if mask is None else 1.2,
                                contour_fofc=None if mask is None else 3.0,
                                ncs_ops=st.ncs)
+
+    # Create ChimeraX script
+    spa.fofc.write_chimerax_script(cxc_out="{}_chimerax.cxc".format(args.output_prefix),
+                                   model_file="{}.mmcif".format(args.output_prefix), # ChimeraX handles mmcif just fine
+                                   fo_mrc_file="diffmap_normalized_fo.mrc",
+                                   fofc_mrc_file="diffmap_normalized_fofc.mrc")
 # calc_fofc()
 
 def write_final_summary(st, refmac_summary, fscavg_text, output_prefix, is_mask_given):

--- a/servalcat/spa/run_refmac.py
+++ b/servalcat/spa/run_refmac.py
@@ -362,6 +362,9 @@ Weight used: {final_weight}
 Open refined model and diffmap.mtz with COOT:
 coot --script {prefix}_coot.py
 
+Open refined model, map and difference map with ChimeraX/ISOLDE:
+chimerax {prefix}_chimerax.cxc
+
 {map_peaks_msg}
 =============================================================================
 """.format(rmsbond=refmac_summary["cycles"][-1].get("rms_bond", "???"),

--- a/servalcat/spa/run_refmac.py
+++ b/servalcat/spa/run_refmac.py
@@ -315,8 +315,8 @@ def calc_fofc(st, st_expanded, maps, monlib, model_format, args, diffmap_prefix=
     # Create ChimeraX script
     spa.fofc.write_chimerax_script(cxc_out="{}_chimerax.cxc".format(args.output_prefix),
                                    model_file="{}.mmcif".format(args.output_prefix), # ChimeraX handles mmcif just fine
-                                   fo_mrc_file="diffmap_normalized_fo.mrc",
-                                   fofc_mrc_file="diffmap_normalized_fofc.mrc")
+                                   fo_mrc_file="{}_normalized_fo.mrc".format(diffmap_prefix),
+                                   fofc_mrc_file="{}_normalized_fofc.mrc".format(diffmap_prefix))
 # calc_fofc()
 
 def write_final_summary(st, refmac_summary, fscavg_text, output_prefix, is_mask_given):


### PR DESCRIPTION
Hi,

This PR adds code to generate a command file for ChimeraX to open the results of `refine_spa` in ChimeraX/ISOLDE. The new code mirrors closely what is done to generate the script for Coot, so I think it should work fine. But I could not test it because the build failed when I tried to `pip install` my local repository into a clean conda environment (I could check that this build failure is not caused by the new code, but otherwise I don't have time to investigate and fix it so I could test this new code).