### PR TITLE
Fix a log message in fofc

### DIFF
--- a/servalcat/spa/fofc.py
+++ b/servalcat/spa/fofc.py
@@ -464,7 +464,11 @@ def main(args):
     logger.writeln("coot --script " + py_out)
     if mask is not None:
         logger.writeln("\nWant to list Fo-Fc map peaks? Try:")
-        logger.writeln("servalcat util map_peaks --map {}_normalized_fofc.mrc --model {} --abs_level 4.0".format(args.output_prefix, args.model))
+        if omit_h_electron:
+            logger.writeln("servalcat util map_peaks --map {}_normalized_fofc_flipsign.mrc --model {} --abs_level 4.0".format(args.output_prefix, args.model))
+        else:
+            logger.writeln("servalcat util map_peaks --map {}_normalized_fofc.mrc --model {} --abs_level 4.0".format(args.output_prefix, args.model))
+
 # main()
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hello,

This commit fixes a log message from `servalcat fofc` that suggests a non-existing map file for the command to search for peaks when the option `--omit_h_electron` is used.

There is no code change otherwise.

I hope this helps!